### PR TITLE
検索結果が1件のみだった場合への対応

### DIFF
--- a/jpndlpy/response.py
+++ b/jpndlpy/response.py
@@ -67,7 +67,12 @@ class JapanNdlResponse():
         """
         if 'item' in root:
             items = root['item']
-            self.extract_items(items)
+            itemlist = []
+            if type(items) is dict:
+                itemlist.append(items)
+            else:
+                itemlist = items
+            self.extract_items(itemlist)
 
     def xml_to_dict(self):
         """ xml to dict """


### PR DESCRIPTION
検索結果が1件のみだった場合と複数の場合とで、rootの中のKey='item'の中の形式が変わります。複数の場合にはリストに各item情報が辞書で格納されているのですが、1件の場合には辞書が直置きです。