### PR TITLE
'dc:creator'の中身がNoneだった場合への対応

### DIFF
--- a/jpndlpy/item_entity.py
+++ b/jpndlpy/item_entity.py
@@ -66,6 +66,8 @@ class ItemEntity:
         creator_list = []
         if 'dc:creator' in item:
             creator_list = item['dc:creator']
+            if not creator_list:
+                return''
         else:
             return ''
 


### PR DESCRIPTION
下のAPIの仕様変更があったのかわかりませんが、たまに'dc:creator'の中身がNoneのため、その後の処理でエラーが起きていました。アドホックな修正方法ですみません。