### PR TITLE
いくつかの例外を回避する

### DIFF
--- a/jpndlpy/client.py
+++ b/jpndlpy/client.py
@@ -88,13 +88,16 @@ class JapanNdlClient(JapanNdlClientBase):
         """
 
         data, errs = self.validation_serializer(kwargs)
-        if not errs:
+        if not errs and len(data) > 0:
             self.response = self.get(data)
             return self.response
         else:
-            erros_mes = ''.join(
-                [key + ' : ' + errs[key][0] + '\n' for key in errs]
-            )
+            if errs:
+                erros_mes = ''.join(
+                    [key + ' : ' + errs[key][0] + '\n' for key in errs]
+                )
+            else:
+                erros_mes = 'Missing data.'
             raise Exception(erros_mes)
 
     def validation_serializer(self, kwargs)->tuple:

--- a/jpndlpy/client.py
+++ b/jpndlpy/client.py
@@ -86,9 +86,8 @@ class JapanNdlClient(JapanNdlClientBase):
         items : json
             複数の図書情報
         """
-
         data, errs = self.validation_serializer(kwargs)
-        if not errs and len(data) > 0:
+        if not errs and len(data) > 1:
             self.response = self.get(data)
             return self.response
         else:

--- a/jpndlpy/item_entity.py
+++ b/jpndlpy/item_entity.py
@@ -5,6 +5,9 @@ created by @shimakaze-git
 '''
 import json
 import re
+# XXX
+import logging
+import pprint
 
 
 class ItemEntity:
@@ -29,6 +32,10 @@ class ItemEntity:
         Returns:
             None
         """
+        logger = logging.getLogger("jpndlpy")
+        logger.debug("--------------------")
+        logger.debug(pprint.pformat(item))
+        logger.debug("--------------------")
         self._title = item['title'] if 'title' in item else ""
         self._link = item['link'] if 'link' in item else ""
 

--- a/jpndlpy/item_entity.py
+++ b/jpndlpy/item_entity.py
@@ -5,9 +5,6 @@ created by @shimakaze-git
 '''
 import json
 import re
-# XXX
-import logging
-import pprint
 
 
 class ItemEntity:
@@ -32,10 +29,6 @@ class ItemEntity:
         Returns:
             None
         """
-        logger = logging.getLogger("jpndlpy")
-        logger.debug("--------------------")
-        logger.debug(pprint.pformat(item))
-        logger.debug("--------------------")
         self._title = item['title'] if 'title' in item else ""
         self._link = item['link'] if 'link' in item else ""
 

--- a/jpndlpy/response.py
+++ b/jpndlpy/response.py
@@ -7,9 +7,6 @@ created by @shimakaze-git
 import re
 import xmltodict
 import json
-# XXX
-import logging
-import pprint
 
 from xml.etree import ElementTree as ET
 
@@ -59,11 +56,8 @@ class JapanNdlResponse():
     def serialize(self):
         ''' serialization jsonResponse
         '''
-        logger = logging.getLogger("jpndlpy")
-
         # root = self.xml_parse()
         root = self.xml_to_dict()
-        logger.debug(pprint.pformat(root))
 
         """ 検索情報を抽出していく """
         self.extract_search_info(root)
@@ -109,19 +103,10 @@ class JapanNdlResponse():
         '''
         item情報を抽出する
         '''
-        logger = logging.getLogger("jpndlpy")
-        logger.debug('--------------------')
-        logger.debug('extract_items:items')
-        logger.debug(pprint.pformat(items))
-        logger.debug('--------------------')
-
         if type(items) is not list:
             items = [items]
         for item in items:
             """ Entity Object """
-            logger.debug('extract_items:item')
-            logger.debug(pprint.pformat(item))
-            logger.debug('--------------------')
             item_object = ItemEntity()
             item_object.regist(item)
 

--- a/jpndlpy/response.py
+++ b/jpndlpy/response.py
@@ -7,6 +7,9 @@ created by @shimakaze-git
 import re
 import xmltodict
 import json
+# XXX
+import logging
+import pprint
 
 from xml.etree import ElementTree as ET
 
@@ -56,8 +59,11 @@ class JapanNdlResponse():
     def serialize(self):
         ''' serialization jsonResponse
         '''
+        logger = logging.getLogger("jpndlpy")
+
         # root = self.xml_parse()
         root = self.xml_to_dict()
+        logger.debug(pprint.pformat(root))
 
         """ 検索情報を抽出していく """
         self.extract_search_info(root)
@@ -103,8 +109,19 @@ class JapanNdlResponse():
         '''
         item情報を抽出する
         '''
+        logger = logging.getLogger("jpndlpy")
+        logger.debug('--------------------')
+        logger.debug('extract_items:items')
+        logger.debug(pprint.pformat(items))
+        logger.debug('--------------------')
+
+        if type(items) is not list:
+            items = [items]
         for item in items:
             """ Entity Object """
+            logger.debug('extract_items:item')
+            logger.debug(pprint.pformat(item))
+            logger.debug('--------------------')
             item_object = ItemEntity()
             item_object.regist(item)
 

--- a/jpndlpy/validator.py
+++ b/jpndlpy/validator.py
@@ -12,7 +12,7 @@ from marshmallow import Schema, fields, validates, ValidationError
 class SearchTextSchema(Schema):
     dpid = fields.String()
     dpgroupid = fields.String()
-    title = fields.String(required=True)
+    title = fields.String()
     creator = fields.String()
     digitized_publisher = fields.String()
     ndc = fields.String()


### PR DESCRIPTION
* 'title' を必須にしない代わりに、検索キーワードがない場合をエラーにしました。
* root['item'] がたまに配列ではなく辞書型1つで返ってくるので、それをチェックして配列に直すようにしました。